### PR TITLE
spark plugin appears to need backstage-commons 0.19.0

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -32,7 +32,7 @@
     "@backstage/plugin-catalog-import": "^0.9.6",
     "@backstage/plugin-catalog-react": "^1.4.0",
     "@backstage/plugin-github-actions": "^0.5.16",
-    "@backstage/plugin-kubernetes": "^0.7.9",
+    "@backstage/plugin-kubernetes": "^0.9.2",
     "@backstage/plugin-org": "^0.6.6",
     "@backstage/plugin-permission-react": "^0.4.11",
     "@backstage/plugin-scaffolder": "^1.12.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -16,7 +16,7 @@
     "build-image": "docker build ../.. -f Dockerfile --tag backstage"
   },
   "dependencies": {
-    "@backstage/backend-common": "^0.18.3",
+    "@backstage/backend-common": "^0.19.0",
     "@backstage/backend-tasks": "^0.5.0",
     "@backstage/catalog-client": "^1.4.0",
     "@backstage/catalog-model": "^1.2.1",
@@ -26,7 +26,7 @@
     "@backstage/plugin-auth-backend": "^0.18.1",
     "@backstage/plugin-auth-node": "^0.2.12",
     "@backstage/plugin-catalog-backend": "^1.8.0",
-    "@backstage/plugin-kubernetes-backend": "^0.9.4",
+    "@backstage/plugin-kubernetes-backend": "^0.10.0",
     "@backstage/plugin-permission-common": "^0.7.4",
     "@backstage/plugin-permission-node": "^0.7.6",
     "@backstage/plugin-proxy-backend": "^0.2.37",

--- a/packages/backend/src/plugins/kubernetes.ts
+++ b/packages/backend/src/plugins/kubernetes.ts
@@ -11,6 +11,7 @@ export default async function createPlugin(
         logger: env.logger,
         config: env.config,
         catalogApi,
+        permissions: env.permissions,
     }).build();
     return router;
 }


### PR DESCRIPTION
Had to update `backends-common` for the spark plugin to start successfully. Otherwise I would receive the following error:

```
❯ yarn start-backend
yarn run v1.22.19
$ yarn workspace backend start
$ backstage-cli package start
Build succeeded
/Users/nkaviani/workspaces/git/cnoe/backstage-app/packages/backend/dist/main.js:411
/******/                        throw e;
                                ^

TypeError: Cannot read properties of undefined (reading 'redacter')
    at Object.<anonymous> (/Users/nkaviani/workspaces/git/cnoe/backstage-app/node_modules/@backstage/backend-common/dist/index.cjs.js:110:46)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Module.require (node:internal/modules/cjs/loader:1141:19)
    at require (node:internal/modules/cjs/helpers:110:18)
    at Object.<anonymous> (/Users/nkaviani/workspaces/git/cnoe/backstage-app/node_modules/@backstage/backend-app-api/dist/index.cjs.js:24:21)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
```

Also, had to bump the front-end and backend kubernetes plugins and make tweaks to the code for the spark changes to remain compatible.