### PR TITLE
Updated argoworkflows to query workflows based on component annotation

### DIFF
--- a/plugins/argo-workflows/src/api/ArgoWorkflows.ts
+++ b/plugins/argo-workflows/src/api/ArgoWorkflows.ts
@@ -33,8 +33,10 @@ export class ArgoWorkflows implements ArgoWorkflowsApi {
     namespace: string,
     labels: string | undefined
   ): Promise<IoArgoprojWorkflowV1alpha1WorkflowList> {
-    const ns = namespace !== undefined ? namespace : "default";
-    const path = `/apis/${API_VERSION}/namespaces/${ns}/${WORKFLOW_PLURAL}`;
+    let path = `/apis/${API_VERSION}/${WORKFLOW_PLURAL}`;
+    if(namespace !== undefined){
+      path = `/apis/${API_VERSION}/namespaces/${namespace}/${WORKFLOW_PLURAL}`;
+    }
     const query = new URLSearchParams({
       [K8s_API_TIMEOUT]: "30",
     });

--- a/plugins/argo-workflows/src/api/index.ts
+++ b/plugins/argo-workflows/src/api/index.ts
@@ -1,24 +1,24 @@
-import { createApiRef } from "@backstage/core-plugin-api";
+import { createApiRef } from '@backstage/core-plugin-api';
 
 import {
   IoArgoprojWorkflowV1alpha1WorkflowList,
   IoArgoprojWorkflowV1alpha1WorkflowTemplateList,
-} from "./generated/api";
+} from './generated/api';
 
-export { ArgoWorkflows } from "./ArgoWorkflows";
+export { ArgoWorkflows } from './ArgoWorkflows';
 
 export const argoWorkflowsApiRef = createApiRef<ArgoWorkflowsApi>({
-  id: "plugin.argoworkflows",
+  id: 'plugin.argoworkflows',
 });
 export interface ArgoWorkflowsApi {
   getWorkflows(
     clusterName: string | undefined,
     namespace: string | undefined,
-    labels: string | undefined
+    labels: string | undefined,
   ): Promise<IoArgoprojWorkflowV1alpha1WorkflowList>;
   getWorkflowTemplates(
     clusterName: string | undefined,
-    namespace: string,
-    labels: string | undefined
+    namespace: string | undefined,
+    labels: string | undefined,
   ): Promise<IoArgoprojWorkflowV1alpha1WorkflowTemplateList>;
 }

--- a/plugins/argo-workflows/src/components/utils.ts
+++ b/plugins/argo-workflows/src/components/utils.ts
@@ -2,6 +2,7 @@ import { Entity } from '@backstage/catalog-model';
 import {
   ARGO_WORKFLOWS_LABEL_SELECTOR_ANNOTATION,
   CLUSTER_NAME_ANNOTATION,
+  K8S_NAMESPACE_ANNOTATION,
   ARGO_WORKFLOWS_NAMESPACE_ANNOTATION,
 } from '../plugin';
 
@@ -19,7 +20,14 @@ export type getAnnotationValuesOutput = {
 };
 
 export function getAnnotationValues(entity: Entity): getAnnotationValuesOutput {
-  const ns = entity.metadata.annotations?.[ARGO_WORKFLOWS_NAMESPACE_ANNOTATION];
+  let ns = entity.metadata.annotations?.[ARGO_WORKFLOWS_NAMESPACE_ANNOTATION];
+  if (
+    entity.metadata.annotations?.[ARGO_WORKFLOWS_NAMESPACE_ANNOTATION] ===
+      undefined &&
+    entity.metadata.annotations?.[K8S_NAMESPACE_ANNOTATION] !== undefined
+  ) {
+    ns = entity.metadata.annotations?.[K8S_NAMESPACE_ANNOTATION];
+  }
   const clusterName = entity.metadata.annotations?.[CLUSTER_NAME_ANNOTATION];
   const labelSelector =
     entity.metadata?.annotations?.[ARGO_WORKFLOWS_LABEL_SELECTOR_ANNOTATION];

--- a/plugins/argo-workflows/src/components/utils.ts
+++ b/plugins/argo-workflows/src/components/utils.ts
@@ -1,30 +1,28 @@
-import {Entity} from "@backstage/catalog-model";
+import { Entity } from '@backstage/catalog-model';
 import {
   ARGO_WORKFLOWS_LABEL_SELECTOR_ANNOTATION,
   CLUSTER_NAME_ANNOTATION,
-  K8S_NAMESPACE_ANNOTATION,
-} from "../plugin";
+  ARGO_WORKFLOWS_NAMESPACE_ANNOTATION,
+} from '../plugin';
 
 export function trimBaseUrl(argoWorkflowsBaseUrl: string | undefined) {
-  if (argoWorkflowsBaseUrl && argoWorkflowsBaseUrl.endsWith("/")) {
+  if (argoWorkflowsBaseUrl && argoWorkflowsBaseUrl.endsWith('/')) {
     return argoWorkflowsBaseUrl.substring(0, argoWorkflowsBaseUrl.length - 1);
   }
   return argoWorkflowsBaseUrl;
 }
 
 export type getAnnotationValuesOutput = {
-  ns: string;
+  ns?: string;
   clusterName?: string;
   labelSelector?: string;
 };
 
 export function getAnnotationValues(entity: Entity): getAnnotationValuesOutput {
-  const ns =
-    entity.metadata.annotations?.[K8S_NAMESPACE_ANNOTATION] !== undefined
-      ? entity.metadata.annotations?.[K8S_NAMESPACE_ANNOTATION]
-      : "default";
+  const ns = entity.metadata.annotations?.[ARGO_WORKFLOWS_NAMESPACE_ANNOTATION];
   const clusterName = entity.metadata.annotations?.[CLUSTER_NAME_ANNOTATION];
-  const labelSelector = entity.metadata?.annotations?.[ARGO_WORKFLOWS_LABEL_SELECTOR_ANNOTATION]
+  const labelSelector =
+    entity.metadata?.annotations?.[ARGO_WORKFLOWS_LABEL_SELECTOR_ANNOTATION];
   return {
     ns: ns,
     clusterName: clusterName,

--- a/plugins/argo-workflows/src/plugin.ts
+++ b/plugins/argo-workflows/src/plugin.ts
@@ -4,20 +4,21 @@ import {
   createRoutableExtension,
   discoveryApiRef,
   fetchApiRef,
-} from "@backstage/core-plugin-api";
-import {Entity} from "@backstage/catalog-model";
+} from '@backstage/core-plugin-api';
+import { Entity } from '@backstage/catalog-model';
 
-import {rootRouteRef} from "./routes";
-import {ArgoWorkflows, argoWorkflowsApiRef} from "./api";
-import {kubernetesApiRef} from "@backstage/plugin-kubernetes";
+import { rootRouteRef } from './routes';
+import { ArgoWorkflows, argoWorkflowsApiRef } from './api';
+import { kubernetesApiRef } from '@backstage/plugin-kubernetes';
 
-export const CLUSTER_NAME_ANNOTATION = "argo-workflows.cnoe.io/cluster-name";
-export const K8S_NAMESPACE_ANNOTATION = "backstage.io/kubernetes-namespace";
+export const CLUSTER_NAME_ANNOTATION = 'argo-workflows.cnoe.io/cluster-name';
+export const ARGO_WORKFLOWS_NAMESPACE_ANNOTATION =
+  'argo-workflows.cnoe.io/namespace';
 export const ARGO_WORKFLOWS_LABEL_SELECTOR_ANNOTATION =
-  "argo-workflows.cnoe.io/label-selector";
+  'argo-workflows.cnoe.io/label-selector';
 
 export const argoWorkflowsPlugin = createPlugin({
-  id: "argo-workflows",
+  id: 'argo-workflows',
   routes: {
     root: rootRouteRef,
   },
@@ -29,7 +30,7 @@ export const argoWorkflowsPlugin = createPlugin({
         kubernetesApi: kubernetesApiRef,
         fetchApi: fetchApiRef,
       },
-      factory: ({discoveryApi, kubernetesApi, fetchApi}) =>
+      factory: ({ discoveryApi, kubernetesApi, fetchApi }) =>
         new ArgoWorkflows(discoveryApi, kubernetesApi, fetchApi),
     }),
   ],
@@ -37,33 +38,35 @@ export const argoWorkflowsPlugin = createPlugin({
 
 export const ArgoWorkflowsPage = argoWorkflowsPlugin.provide(
   createRoutableExtension({
-    name: "ArgoWorkflowsPage",
+    name: 'ArgoWorkflowsPage',
     component: () =>
-      import("./components/Overview").then((m) => m.ArgoWorkflowsOverviewPage),
+      import('./components/Overview').then(m => m.ArgoWorkflowsOverviewPage),
     mountPoint: rootRouteRef,
-  })
+  }),
 );
 
 export const EntityArgoWorkflowsOverviewCard = argoWorkflowsPlugin.provide(
   createRoutableExtension({
-    name: "ArgoWorkflowsOverviewCard",
+    name: 'ArgoWorkflowsOverviewCard',
     component: () =>
-      import("./components/Overview").then((m) => m.ArgoWorkflowsOverviewCard),
+      import('./components/Overview').then(m => m.ArgoWorkflowsOverviewCard),
     mountPoint: rootRouteRef,
-  })
+  }),
 );
 
 export const EntityArgoWorkflowsTemplateOverviewCard =
   argoWorkflowsPlugin.provide(
     createRoutableExtension({
-      name: "ArgoWorkflowsTemplatesOverviewCard",
+      name: 'ArgoWorkflowsTemplatesOverviewCard',
       component: () =>
-        import("./components/Overview").then(
-          (m) => m.ArgoWorkflowsTemplatesOverviewCard
+        import('./components/Overview').then(
+          m => m.ArgoWorkflowsTemplatesOverviewCard,
         ),
       mountPoint: rootRouteRef,
-    })
+    }),
   );
 
 export const isArgoWorkflowsAvailable = (entity: Entity) =>
-  Boolean(entity?.metadata.annotations?.[ARGO_WORKFLOWS_LABEL_SELECTOR_ANNOTATION]);
+  Boolean(
+    entity?.metadata.annotations?.[ARGO_WORKFLOWS_LABEL_SELECTOR_ANNOTATION],
+  );

--- a/plugins/argo-workflows/src/plugin.ts
+++ b/plugins/argo-workflows/src/plugin.ts
@@ -12,6 +12,7 @@ import { ArgoWorkflows, argoWorkflowsApiRef } from './api';
 import { kubernetesApiRef } from '@backstage/plugin-kubernetes';
 
 export const CLUSTER_NAME_ANNOTATION = 'argo-workflows.cnoe.io/cluster-name';
+export const K8S_NAMESPACE_ANNOTATION = 'backstage.io/kubernetes-namespace';
 export const ARGO_WORKFLOWS_NAMESPACE_ANNOTATION =
   'argo-workflows.cnoe.io/namespace';
 export const ARGO_WORKFLOWS_LABEL_SELECTOR_ANNOTATION =


### PR DESCRIPTION
Currently ArgoWorkflows plugin is leveraging "backstage.io/kubernetes-namespace" annotation to search for workflows based on label selector, so we have added argo workflows specific namespace annotation to have the plugin search for specified namespace, if we dont annotate namespace, it will search across the namesapces.