### PR TITLE
Upgrade Dockerfile and CI from Node 18 to Node 24 (LTS)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
       - name: Run tests
         run: |
           yarn install --frozen-lockfile --network-timeout 600000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1 - Create yarn install skeleton layer
-FROM node:18-bookworm-slim AS packages
+FROM node:24-bookworm-slim AS packages
 
 WORKDIR /app
 COPY package.json yarn.lock ./
@@ -12,7 +12,7 @@ COPY plugins plugins
 RUN find packages \! -name "package.json" -mindepth 2 -maxdepth 2 -exec rm -rf {} \+
 
 # Stage 2 - Install dependencies and build packages
-FROM node:18-bookworm-slim AS build
+FROM node:24-bookworm-slim AS build
 
 USER node
 WORKDIR /app
@@ -34,7 +34,7 @@ RUN mkdir packages/backend/dist/skeleton packages/backend/dist/bundle \
     && tar xzf packages/backend/dist/bundle.tar.gz -C packages/backend/dist/bundle
 
 # Stage 3 - Build the actual backend image and install production dependencies
-FROM node:18-bookworm-slim
+FROM node:24-bookworm-slim
 
 # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
 # Install packages needed to get utility binaries

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22 || 24"
   },
   "scripts": {
     "dev": "concurrently \"yarn start\" \"yarn start-backend\"",


### PR DESCRIPTION
## Summary

Upgrade the Docker base image and PR CI workflow from Node 18 to Node 24 (Active LTS) to fix broken builds.

## Problem

The `build-and-push-image` job and PR CI both fail during `yarn install` because a transitive dependency (`undici@7.25.0`) requires Node `>=20.18.1`, but Node 18.20.8 is used:

```
error undici@7.25.0: The engine "node" is incompatible with this module. Expected version ">=20.18.1". Got "18.20.8"
```

## Fix

- **Dockerfile**: Update all three `FROM node:18-bookworm-slim` stages to `node:24-bookworm-slim`
- **pr.yaml**: Update `setup-node` version from 18 to 24

## Why Node 24?

- **Node 18**: EOL as of April 30, 2025
- **Node 20**: Maintenance LTS (EOL April 2026)
- **Node 22**: Maintenance LTS (EOL April 2027)
- **Node 24**: Active LTS since October 2025 (EOL April 2028) ✅

Node 24 is the sole Active LTS release and aligns with the GitHub Actions runner upgrade to Node 24 in #52.

## Related

- Fixes the Docker build and CI failures exposed by #52 and #53 (which upgraded GitHub Actions but did not update the Node runtime version)