### PR TITLE
fix: use modern ENV key=value format in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN --mount=type=cache,target=/home/node/.cache/yarn,sharing=locked,uid=1000,gid
 COPY --from=build --chown=node:node /app/packages/backend/dist/bundle/ ./
 COPY --chown=node:node app-config.yaml app-config.production.yaml ./
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 ENV NODE_OPTIONS="--no-node-snapshot"
 
 CMD ["node", "packages/backend", "--config", "app-config.yaml", "--config", "app-config.production.yaml"]


### PR DESCRIPTION
Fixes Docker build warning about legacy ENV format on line 73.