### PR TITLE
feat: backstage-override package for seamless local stack setup

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -72,22 +72,47 @@ tasks:
   # ===== idpbuilder Local Stack =====
 
   stack:up:
-    desc: Bring up full local stack (ref-implementation + Kro + Backstage)
+    desc: Bring up full local stack (ref-implementation + custom Backstage + Kro)
     cmds:
       - task: stack:idp
+      - task: stack:keycloak-fix
       - task: stack:kro
       - task: stack:patch
-      - task: stack:deploy
 
   stack:idp:
-    desc: Start idpbuilder ref-implementation
+    desc: Start idpbuilder with ref-implementation and custom Backstage override
     cmds:
       - |
         idpbuilder create --use-path-routing \
-          --package https://github.com/cnoe-io/stacks//ref-implementation
+          --package https://github.com/cnoe-io/stacks//ref-implementation \
+          --package ./examples/local-stack
       - echo "Waiting for cluster to stabilize..."
       - kubectl config use-context {{.K8S_CONTEXT}}
-      - kubectl wait --for=condition=Available deployment/backstage -n {{.BACKSTAGE_NS}} --timeout=600s
+
+  stack:keycloak-fix:
+    desc: Fix keycloak-clients secret (workaround for broken kubectl download in config job)
+    cmds:
+      - kubectl config use-context {{.K8S_CONTEXT}}
+      - |
+        echo "Waiting for keycloak config job to complete..."
+        kubectl wait --for=condition=Complete job/config -n keycloak --timeout=300s 2>/dev/null || true
+      - |
+        BACKSTAGE_SECRET=$(kubectl logs job/config -n keycloak 2>/dev/null | grep "BACKSTAGE_CLIENT_SECRET=" | tail -1 | sed 's/.*BACKSTAGE_CLIENT_SECRET=//')
+        ARGO_SECRET=$(kubectl logs job/config -n keycloak 2>/dev/null | grep "ARGO_WORKFLOWS_CLIENT_SECRET=" | tail -1 | sed 's/.*ARGO_WORKFLOWS_CLIENT_SECRET=//')
+        if [ -n "$BACKSTAGE_SECRET" ] && ! kubectl get secret keycloak-clients -n keycloak 2>/dev/null; then
+          echo "Creating keycloak-clients secret from job logs..."
+          kubectl -n keycloak create secret generic keycloak-clients \
+            --from-literal=BACKSTAGE_CLIENT_SECRET="$BACKSTAGE_SECRET" \
+            --from-literal=ARGO_WORKFLOWS_CLIENT_SECRET="$ARGO_SECRET" \
+            --from-literal=ARGOCD_SESSION_TOKEN=""
+          kubectl annotate externalsecret backstage-oidc -n backstage force-sync=$(date +%s) --overwrite 2>/dev/null || true
+        fi
+      - |
+        echo "Waiting for backstage-env-vars secret..."
+        until kubectl get secret backstage-env-vars -n backstage 2>/dev/null; do sleep 5; done
+      - |
+        echo "Waiting for backstage deployment..."
+        kubectl wait --for=condition=Available deployment/backstage -n {{.BACKSTAGE_NS}} --timeout=300s 2>/dev/null || true
 
   stack:kro:
     desc: Install Kro operator and sample ResourceGraphDefinition
@@ -104,11 +129,16 @@ tasks:
       - kubectl apply -f examples/local-stack/backstage-patch/manifests/install.yaml
 
   stack:deploy:
-    desc: Build, load, and deploy local Backstage image to the cluster
+    desc: Build local image, load into cluster, and restart backstage
     cmds:
       - task: docker:build
       - task: stack:load
-      - task: stack:swap
+      - kubectl config use-context {{.K8S_CONTEXT}}
+      - kubectl -n {{.BACKSTAGE_NS}} set image deployment/backstage backstage={{.IMAGE_NAME}}:{{.IMAGE_TAG}}
+      - |
+        kubectl -n {{.BACKSTAGE_NS}} patch deployment backstage \
+          -p '{"spec":{"template":{"spec":{"containers":[{"name":"backstage","imagePullPolicy":"Never"}]}}}}'
+      - kubectl -n {{.BACKSTAGE_NS}} rollout status deployment/backstage --timeout=90s
 
   stack:load:
     desc: Load local Docker image into kind cluster
@@ -119,14 +149,18 @@ tasks:
           ctr -n k8s.io images import --all-platforms -
 
   stack:swap:
-    desc: Swap Backstage deployment to use local image
+    desc: Swap Backstage deployment to use a specific image (usage -- task stack:swap IMAGE_SHA=abc123)
     cmds:
       - kubectl config use-context {{.K8S_CONTEXT}}
-      - kubectl -n {{.BACKSTAGE_NS}} set image deployment/backstage backstage={{.IMAGE_NAME}}:{{.IMAGE_TAG}}
+      - |
+        docker pull {{.IMAGE_NAME}}:{{.IMAGE_SHA}} && \
+        docker save {{.IMAGE_NAME}}:{{.IMAGE_SHA}} | \
+          docker exec -i {{.KIND_CLUSTER}}-control-plane \
+          ctr -n k8s.io images import --all-platforms -
+      - kubectl -n {{.BACKSTAGE_NS}} set image deployment/backstage backstage={{.IMAGE_NAME}}:{{.IMAGE_SHA}}
       - |
         kubectl -n {{.BACKSTAGE_NS}} patch deployment backstage \
           -p '{"spec":{"template":{"spec":{"containers":[{"name":"backstage","imagePullPolicy":"Never"}]}}}}'
-      - kubectl -n argocd patch application backstage --type merge -p '{"spec":{"syncPolicy":null}}'
       - kubectl -n {{.BACKSTAGE_NS}} rollout status deployment/backstage --timeout=90s
 
   stack:iterate:

--- a/examples/local-stack/README.md
+++ b/examples/local-stack/README.md
@@ -1,78 +1,73 @@
 # Local Testing Stack for Backstage Plugin Integration
 
-Add-on to the [cnoe-io/stacks ref-implementation](https://github.com/cnoe-io/stacks/tree/main/ref-implementation) that adds Kro operator and updated Backstage config for verifying all plugin integrations.
+Add-on to the [cnoe-io/stacks ref-implementation](https://github.com/cnoe-io/stacks/tree/main/ref-implementation) that provides a custom Backstage image with CNOE UI, Kro operator, and all plugin integrations pre-configured.
 
 ## Prerequisites
 
 - [idpbuilder](https://github.com/cnoe-io/idpbuilder/releases/latest) v0.3.0+
+- [task](https://taskfile.dev/installation/) (Taskfile runner)
 - kubectl, docker, helm 3.x
 - 6 GB RAM allocated to Docker
 
-## Setup
+## Quick Start
 
-### 1. Run the ref-implementation
-
-```bash
-idpbuilder create --use-path-routing \
-  --package https://github.com/cnoe-io/stacks//ref-implementation
-```
-
-Wait ~6 minutes. Track progress at https://cnoe.localtest.me:8443/argocd
-
-### 2. Install Kro operator
+From the repo root:
 
 ```bash
-helm install kro oci://registry.k8s.io/kro/charts/kro \
-  --namespace kro-system --create-namespace
+task stack:up
 ```
 
-### 3. Apply Kro sample and Backstage patches
-
-```bash
-# Wait for CRD, then apply sample ResourceGraphDefinition
-kubectl wait --for=condition=Established crd/resourcegraphdefinitions.kro.run --timeout=60s
-kubectl apply -f examples/local-stack/kro/manifests/install.yaml
-
-# Apply Backstage RBAC and config for Kro
-kubectl apply -f examples/local-stack/backstage-patch/manifests/install.yaml
-```
-
-### 4. Build and load local Backstage image
-
-```bash
-docker build -t ghcr.io/cnoe-io/backstage-app:local .
-docker save ghcr.io/cnoe-io/backstage-app:local | \
-  docker exec -i localdev-control-plane ctr -n k8s.io images import --all-platforms -
-```
-
-### 5. Swap Backstage deployment
-
-```bash
-kubectl -n backstage set image deployment/backstage \
-  backstage=ghcr.io/cnoe-io/backstage-app:local
-kubectl -n backstage patch deployment backstage \
-  -p '{"spec":{"template":{"spec":{"containers":[{"name":"backstage","imagePullPolicy":"Never"}]}}}}'
-kubectl -n argocd patch application backstage --type merge \
-  -p '{"spec":{"syncPolicy":null}}'
-```
-
-### 6. Add guest auth (for testing without Keycloak)
-
-```bash
-kubectl -n backstage get configmap backstage-config -o yaml | \
-  sed 's/keycloak-oidc:/guest:\n          dangerouslyAllowOutsideDevelopment: true\n        keycloak-oidc:/' | \
-  kubectl apply -f -
-kubectl -n backstage rollout restart deployment/backstage
-```
+This single command:
+1. Starts idpbuilder with ref-implementation + custom Backstage override
+2. Fixes the keycloak-clients secret (workaround for upstream bug)
+3. Installs Kro operator + sample ResourceGraphDefinition
+4. Applies Backstage RBAC patches for Kro
 
 ## Access
 
 | Service | URL | Credentials |
 |---|---|---|
-| Backstage | https://cnoe.localtest.me:8443/ | guest or `user1` / `idpbuilder get secrets` |
-| ArgoCD | https://cnoe.localtest.me:8443/argocd | admin / `idpbuilder get secrets -p argocd` |
-| Gitea | https://cnoe.localtest.me:8443/gitea | giteaAdmin / `idpbuilder get secrets -p gitea` |
-| Keycloak | https://cnoe.localtest.me:8443/keycloak | cnoe-admin / `idpbuilder get secrets` |
+| Backstage | https://cnoe.localtest.me:8443/ | Guest sign-in |
+| ArgoCD | https://cnoe.localtest.me:8443/argocd | admin / `task stack:secrets` |
+| Gitea | https://cnoe.localtest.me:8443/gitea | giteaAdmin / `task stack:secrets` |
+| Keycloak | https://cnoe.localtest.me:8443/keycloak | cnoe-admin / `task stack:secrets` |
+
+## How It Works
+
+The `backstage-override.yaml` creates an ArgoCD Application named `backstage` that overrides the ref-implementation's default Backstage deployment with:
+- CI-built image from `ghcr.io/cnoe-io/backstage-app`
+- Guest auth enabled alongside Keycloak OIDC
+- `NODE_OPTIONS=--no-node-snapshot` for scaffolder compatibility
+- Config-driven homepage quick links pointing to local services
+- Kubernetes cluster auto-detection via service account
+
+## Useful Commands
+
+| Command | Description |
+|---|---|
+| `task stack:up` | Full stack from scratch |
+| `task stack:deploy` | Build local image and deploy to cluster |
+| `task stack:iterate` | Fast rebuild cycle after code changes (~2 min) |
+| `task stack:swap IMAGE_SHA=abc123` | Deploy a specific CI-built image |
+| `task stack:status` | Check all components |
+| `task stack:logs` | Tail backstage logs |
+| `task stack:port-forward` | Port-forward to localhost:7007 |
+| `task stack:secrets` | Show idpbuilder credentials |
+| `task stack:down` | Delete the cluster |
+
+## Updating the Backstage Image
+
+To use the latest CI-built image, update the image tag in `backstage-override/manifests/install.yaml`:
+
+```yaml
+image: ghcr.io/cnoe-io/backstage-app:<new-git-sha>
+```
+
+Or use a locally built image:
+
+```bash
+task stack:deploy
+```
 
 ## Verification
 
@@ -88,32 +83,18 @@ kubectl -n backstage rollout restart deployment/backstage
 | TechDocs | `/docs` — documentation renders |
 | Search | `/search` — results from catalog + techdocs |
 
-## Iterate
-
-```bash
-# After code changes:
-docker build -t ghcr.io/cnoe-io/backstage-app:local .
-docker save ghcr.io/cnoe-io/backstage-app:local | \
-  docker exec -i localdev-control-plane ctr -n k8s.io images import --all-platforms -
-kubectl -n backstage rollout restart deployment/backstage
-```
-
 ## Mock Mode (no cluster needed)
 
 For local development without any external services:
 
 ```bash
-MOCK_MODE=true yarn dev
+task dev:mock
 ```
-
-Mock entities in `examples/local-stack/mock-entities/catalog-info.yaml` are wired to the mock backends with correct annotations for Kubernetes, ArgoCD, Spark, Argo Workflows, and Terraform tabs.
 
 ## Troubleshooting
 
-**Kro controller not starting**: Verify Helm install: `helm list -n kro-system`
+**Keycloak secret not created**: The ref-implementation's config job has a bug downloading kubectl. `task stack:keycloak-fix` handles this automatically, but if it fails, check `kubectl logs job/config -n keycloak`.
 
-**Backstage can't see Kro resources**: Check RBAC: `kubectl auth can-i list resourcegraphdefinitions.kro.run --as=system:serviceaccount:backstage:backstage`
+**Backstage CrashLoopBackOff after image change**: Usually a DB migration conflict. Delete PostgreSQL and let ArgoCD recreate it: `kubectl -n backstage delete statefulset postgresql && kubectl -n backstage delete pvc data-postgresql-0`
 
-**ArgoCD reverts image**: Disable auto-sync (step 5 above)
-
-**Image not found after load**: Ensure `imagePullPolicy: Never` is set on the deployment
+**ArgoCD reverts image**: The backstage-override package should prevent this. If it happens, check `kubectl get application backstage -n argocd -o jsonpath='{.spec.source.repoURL}'` — it should show `cnoe://backstage-override/manifests`.

--- a/examples/local-stack/backstage-override.yaml
+++ b/examples/local-stack/backstage-override.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: backstage
+  namespace: argocd
+  labels:
+    env: dev
+  annotations:
+    argocd.argoproj.io/sync-wave: "40"
+spec:
+  project: default
+  source:
+    repoURL: cnoe://backstage-override/manifests
+    targetRevision: HEAD
+    path: "."
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: backstage
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/examples/local-stack/backstage-override/manifests/install.yaml
+++ b/examples/local-stack/backstage-override/manifests/install.yaml
@@ -1,0 +1,469 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: backstage
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backstage
+  namespace: backstage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backstage-argo-worfklows
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflows
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: read-all
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backstage-argo-worfklows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: backstage-argo-worfklows
+subjects:
+  - kind: ServiceAccount
+    name: backstage
+    namespace: backstage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backstage-read-all
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: read-all
+subjects:
+  - kind: ServiceAccount
+    name: backstage
+    namespace: backstage
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backstage-config
+  namespace: backstage
+data:
+  app-config.yaml: |
+    app:
+      title: CNOE Backstage
+      baseUrl: https://cnoe.localtest.me:8443
+    organization:
+      name: CNOE
+    backend:
+      baseUrl: https://cnoe.localtest.me:8443
+      listen:
+        port: 7007
+      csp:
+        connect-src: ["'self'", 'http:', 'https:']
+      cors:
+        origin: https://cnoe.localtest.me:8443
+        methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
+        credentials: true
+      database:
+        client: pg
+        connection:
+          host: ${POSTGRES_HOST}
+          port: ${POSTGRES_PORT}
+          user: ${POSTGRES_USER}
+          password: ${POSTGRES_PASSWORD}
+      cache:
+        store: memory
+    integrations:
+      gitea:
+        - baseUrl: https://cnoe.localtest.me:8443/gitea
+          host: cnoe.localtest.me:8443
+          username: ${GITEA_USERNAME}
+          password: ${GITEA_PASSWORD}
+        - baseUrl: https://cnoe.localtest.me/gitea
+          host: cnoe.localtest.me
+          username: ${GITEA_USERNAME}
+          password: ${GITEA_PASSWORD}
+    techdocs:
+      builder: 'local'
+      generator:
+        runIn: 'local'
+      publisher:
+        type: 'local'
+    auth:
+      environment: development
+      session:
+        secret: MW2sV-sIPngEl26vAzatV-6VqfsgAx4bPIz7PuE_2Lk=
+      providers:
+        guest:
+          dangerouslyAllowOutsideDevelopment: true
+        keycloak-oidc:
+          development:
+            metadataUrl: ${KEYCLOAK_NAME_METADATA}
+            clientId: backstage
+            clientSecret: ${KEYCLOAK_CLIENT_SECRET}
+            prompt: auto
+    scaffolder:
+      defaultAuthor:
+        name: backstage-scaffolder
+        email: noreply
+      defaultCommitMessage: "backstage scaffolder"
+    catalog:
+      import:
+        entityFilename: catalog-info.yaml
+        pullRequestBranchName: backstage-integration
+      rules:
+        - allow: [Component, System, API, Resource, Location, Template]
+      locations:
+        - type: url
+          target: https://cnoe.localtest.me/gitea/giteaAdmin/idpbuilder-localdev-backstage-templates-entities/raw/branch/main/catalog-info.yaml
+          rules:
+            - allow: [Component, System, API, Resource, Location, Template, User, Group]
+    kubernetes:
+      serviceLocatorMethod:
+        type: 'multiTenant'
+      clusterLocatorMethods:
+        - $include: k8s-config.yaml
+    argocd:
+      username: admin
+      password: ${ARGOCD_ADMIN_PASSWORD}
+      appLocatorMethods:
+        - type: 'config'
+          instances:
+            - name: in-cluster
+              url: https://cnoe.localtest.me:8443/argocd
+              username: admin
+              password: ${ARGOCD_ADMIN_PASSWORD}
+    argoWorkflows:
+      baseUrl: ${ARGO_WORKFLOWS_URL}
+    homepage:
+      quickLinks:
+        - url: /catalog
+          label: Catalog
+          icon: catalog
+        - url: https://cnoe.localtest.me:8443/gitea
+          label: Gitea
+          iconUrl: /img/gitlab.png
+        - url: https://cnoe.localtest.me:8443/argocd
+          label: ArgoCD
+          iconUrl: /img/argocd.png
+        - url: https://cnoe.localtest.me:8443/argo-workflows
+          label: Argo Workflows
+          iconUrl: /img/argo-workflows.png
+        - url: https://cnoe.localtest.me:8443
+          label: Kargo
+          iconUrl: /img/kargo.png
+        - url: https://cnoe.localtest.me:8443/keycloak
+          label: Keycloak
+          iconUrl: /img/keycloak.png
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: k8s-config
+  namespace: backstage
+stringData:
+  k8s-config.yaml: "type: 'config'\nclusters:\n  - url: https://kubernetes.default.svc.cluster.local\n
+    \   name: local\n    authProvider: 'serviceAccount'\n    skipTLSVerify: true\n
+    \   skipMetricsLookup: true\n    serviceAccountToken: \n      $file: /var/run/secrets/kubernetes.io/serviceaccount/token\n
+    \   caData: \n      $file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt\n"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backstage
+  namespace: backstage
+spec:
+  ports:
+    - name: http
+      port: 7007
+      targetPort: http
+  selector:
+    app: backstage
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: postgresql
+  name: postgresql
+  namespace: backstage
+spec:
+  clusterIP: None
+  ports:
+    - name: postgres
+      port: 5432
+  selector:
+    app: postgresql
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backstage
+  namespace: backstage
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backstage
+  template:
+    metadata:
+      labels:
+        app: backstage
+    spec:
+      containers:
+        - command:
+            - node
+            - packages/backend
+            - --config
+            - config/app-config.yaml
+          env:
+            - name: LOG_LEVEL
+              value: debug
+            - name: NODE_TLS_REJECT_UNAUTHORIZED
+              value: "0"
+            - name: NODE_OPTIONS
+              value: "--no-node-snapshot"
+          envFrom:
+            - secretRef:
+                name: backstage-env-vars
+            - secretRef:
+                name: gitea-credentials
+            - secretRef:
+                name: argocd-credentials
+          image: ghcr.io/cnoe-io/backstage-app:5d7cdbc0ffcc65686054a4147606eb4ef046d096
+          name: backstage
+          ports:
+            - containerPort: 7007
+              name: http
+          volumeMounts:
+            - mountPath: /app/config
+              name: backstage-config
+              readOnly: true
+      serviceAccountName: backstage
+      volumes:
+        - name: backstage-config
+          projected:
+            sources:
+              - configMap:
+                  items:
+                    - key: app-config.yaml
+                      path: app-config.yaml
+                  name: backstage-config
+              - secret:
+                  items:
+                    - key: k8s-config.yaml
+                      path: k8s-config.yaml
+                  name: k8s-config
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: postgresql
+  name: postgresql
+  namespace: backstage
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgresql
+  serviceName: service-postgresql
+  template:
+    metadata:
+      labels:
+        app: postgresql
+    spec:
+      containers:
+        - env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: backstage-env-vars
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: backstage-env-vars
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: backstage-env-vars
+                  key: POSTGRES_PASSWORD
+          image: docker.io/library/postgres:15.3-alpine3.18
+          name: postgres
+          ports:
+            - containerPort: 5432
+              name: postgresdb
+          resources:
+            limits:
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 300Mi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: "500Mi"
+---
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: backstage
+  namespace: backstage
+spec:
+  length: 36
+  digits: 5
+  symbols: 5
+  symbolCharacters: "/-+"
+  noUpper: false
+  allowRepeat: true
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: backstage-oidc
+  namespace: backstage
+spec:
+  secretStoreRef:
+    name: keycloak
+    kind: ClusterSecretStore
+  refreshInterval: "0"
+  target:
+    name: backstage-env-vars
+    template:
+      engineVersion: v2
+      data:
+        BACKSTAGE_FRONTEND_URL: https://cnoe.localtest.me:8443/backstage
+        POSTGRES_HOST: postgresql.backstage.svc.cluster.local
+        POSTGRES_PORT: '5432'
+        POSTGRES_DB: backstage
+        POSTGRES_USER: backstage
+        POSTGRES_PASSWORD: "{{.POSTGRES_PASSWORD}}"
+        ARGO_WORKFLOWS_URL: https://cnoe.localtest.me:8443/argo-workflows
+        KEYCLOAK_NAME_METADATA: https://cnoe.localtest.me:8443/keycloak/realms/cnoe/.well-known/openid-configuration
+        KEYCLOAK_CLIENT_SECRET: "{{.BACKSTAGE_CLIENT_SECRET}}"
+        ARGOCD_AUTH_TOKEN: "argocd.token={{.ARGOCD_SESSION_TOKEN}}"
+        ARGOCD_ADMIN_PASSWORD: "{{.ARGOCD_ADMIN_PASSWORD}}"
+        ARGO_CD_URL: 'https://argocd-server.argocd.svc.cluster.local/api/v1/'
+  data:
+    - secretKey: ARGOCD_SESSION_TOKEN
+      remoteRef:
+        key: keycloak-clients
+        property: ARGOCD_SESSION_TOKEN
+    - secretKey: BACKSTAGE_CLIENT_SECRET
+      remoteRef:
+        key: keycloak-clients
+        property: BACKSTAGE_CLIENT_SECRET
+    - secretKey: ARGOCD_ADMIN_PASSWORD
+      remoteRef:
+        key: argocd-initial-admin-secret
+        property: password
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: backstage
+      rewrite:
+        - transform:
+            template: "POSTGRES_PASSWORD"
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: gitea-credentials
+  namespace: backstage
+spec:
+  secretStoreRef:
+    name: gitea
+    kind: ClusterSecretStore
+  refreshInterval: "0"
+  target:
+    name: gitea-credentials
+  data:
+    - secretKey: GITEA_USERNAME
+      remoteRef:
+        key: gitea-credential
+        property: username
+    - secretKey: GITEA_PASSWORD
+      remoteRef:
+        key: gitea-credential
+        property: password
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: argocd-credentials
+  namespace: backstage
+spec:
+  secretStoreRef:
+    name: argocd
+    kind: ClusterSecretStore
+  refreshInterval: "0"
+  target:
+    name: argocd-credentials
+  data:
+    - secretKey: ARGOCD_ADMIN_PASSWORD
+      remoteRef:
+        key: argocd-initial-admin-secret
+        property: password
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: backstage
+  namespace: backstage
+spec:
+  ingressClassName: "nginx"
+  rules:
+    - host: localhost
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backstage
+                port:
+                  name: http
+    - host: cnoe.localtest.me
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backstage
+                port:
+                  name: http


### PR DESCRIPTION
## Summary

Adds a `backstage-override` idpbuilder package that replaces the ref-implementation's default Backstage deployment, eliminating the manual image swap and ArgoCD revert loop.

### What changed

- **`examples/local-stack/backstage-override/`** — Full Backstage deployment manifest with CI-built image, guest auth, NODE_OPTIONS, homepage quick links, and k8s config baked in
- **`examples/local-stack/backstage-override.yaml`** — ArgoCD Application named `backstage` that overrides the ref-implementation's default
- **`Taskfile.yml`** — `task stack:up` is now a single command: idpbuilder + keycloak fix + kro + patches
- **`examples/local-stack/README.md`** — Updated with quick start and troubleshooting

### Problems solved

1. **ArgoCD image revert loop** — Override package owns the `backstage` ArgoCD app, so no more sync conflicts
2. **Keycloak secret bug** — `stack:keycloak-fix` task automatically extracts secrets from job logs
3. **Manual image swap** — CI image is baked into the manifest, no `kubectl set image` needed

### Usage

```bash
task stack:up      # Full stack from scratch
task stack:iterate # Fast rebuild after code changes
task stack:down    # Tear down
```

## Test Plan

- [x] `task --list` shows all stack commands
- [x] Verified backstage-override manifest matches ref-implementation structure
- [x] CI image tag matches current main HEAD